### PR TITLE
fix(deepseek): 修复DeepSeek返回结果包含Markdown标记的问题

### DIFF
--- a/internal/ai/deepseek.go
+++ b/internal/ai/deepseek.go
@@ -83,8 +83,12 @@ func (p *DeepseekProvider) GenerateCommitMessage(ctx context.Context, info *Comm
 		return nil, fmt.Errorf("API返回结果为空")
 	}
 
+	// 清理响应内容中的Markdown格式标记
+	content := result.Choices[0].Message.Content
+	content = cleanMarkdownFormatting(content)
+
 	// 分割标题和正文
-	parts := strings.SplitN(result.Choices[0].Message.Content, "\n\n", 2)
+	parts := strings.SplitN(content, "\n\n", 2)
 	message := &CommitMessage{
 		Title: strings.TrimSpace(parts[0]),
 	}
@@ -93,4 +97,17 @@ func (p *DeepseekProvider) GenerateCommitMessage(ctx context.Context, info *Comm
 	}
 
 	return message, nil
+}
+
+// cleanMarkdownFormatting 清理Markdown格式标记
+func cleanMarkdownFormatting(content string) string {
+	// 移除 ```plaintext 和 ``` 标记
+	content = strings.TrimPrefix(content, "```plaintext")
+	content = strings.TrimPrefix(content, "```")
+	content = strings.TrimSuffix(content, "```")
+
+	// 移除开头的空行
+	content = strings.TrimLeft(content, "\n")
+
+	return content
 }


### PR DESCRIPTION
## 问题描述
     DeepSeek API 返回的提交消息中包含 Markdown 格式标记（```plaintext），导致生成的提交消息格式不正确。

     ## 修复方案
     - 添加 `cleanMarkdownFormatting` 函数清理响应内容
     - 移除 ```plaintext 和 ``` 标记
     - 处理多余的空行

     ## 测试
     - [ ] 使用 DeepSeek 生成提交消息，确认不再出现 Markdown 标记
     - [ ] 确认其他 AI 提供商的功能未受影响

     Fixes #1